### PR TITLE
Balance should not display as £0.00 when null in listing

### DIFF
--- a/resources/view/return/listing/return-listing.html.twig
+++ b/resources/view/return/listing/return-listing.html.twig
@@ -30,13 +30,13 @@
 						<td>
 							{% if not return.hasBalance %}
 								{% if return.payeeIsClient %}
-									{{ (0 - return.calculatedBalance)|price }} (calculated)
+									{{ return.calculatedBalance|price }} (calculated)
 								{% elseif return.payeeIsCustomer %}
 									{{ return.calculatedBalance|price }} (calculated)
 								{% endif %}
 							{% else %}
 								{% if return.payeeIsClient %}
-									{{ (0 - return.balance)|price }}
+									{{ return.balance|price }}
 								{% elseif return.payeeIsCustomer %}
 									{{ return.balance|price }}
 								{% endif %}


### PR DESCRIPTION
When the balance is `null` it means it has not yet been set, so should display a message instead of `£0.00` on this page http://ms.uniformwares.com/admin/return/view/open
