### PR TITLE
no longer show out of stock or non-visible as return option

### DIFF
--- a/src/Controller/OrderReturn/Account/Create.php
+++ b/src/Controller/OrderReturn/Account/Create.php
@@ -253,7 +253,9 @@ class Create extends Controller
 			$productUnits = $this->get('product.unit.loader')->getByProduct($product);
 			if ($productUnits and count($productUnits)) {
 				foreach ($productUnits as $unit) {
-					$units[$product->displayName][$unit->id] = implode($unit->options, ',');
+					if($unit->visible && !array_sum($unit->stock) == 0) {
+						$units[$product->displayName][$unit->id] = implode($unit->options, ',');
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### What does this do?

Prevents out of stock and non-visible products from showing on the exchange
#### How should this be manually tested?

Check no non-visible or out of stock products/units show in the select for exchange.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
