### PR TITLE
Link on return view fix

### DIFF
--- a/resources/view/return/detail/detail.html.twig
+++ b/resources/view/return/detail/detail.html.twig
@@ -11,7 +11,7 @@
 	<div class="container-content tall">
 		<section class="dual-column">
 			<h2 class="title">
-				<a href="{ url('ms.commerce.product.edit.details', {productID: returnItem.productID}) }" data-live>
+				<a href="{{ url('ms.commerce.product.edit.details', {productID: returnItem.productID}) | raw }}" data-live>
 					{{ returnItem.brand }} {{ returnItem.productName }}
 				</a>
 			</h2>


### PR DESCRIPTION
#### What does this do?

Fixes the link to products on the returns pages
#### How should this be manually tested?

Go to a return item and click on the product link.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
