### PR TITLE
Fix views and controllers to deal with standalone returns

### DIFF
--- a/resources/view/return/detail/detail.html.twig
+++ b/resources/view/return/detail/detail.html.twig
@@ -239,9 +239,10 @@
 						<dt>Note</dt>
 						<dd>{{ returnItem.note.note }}</dd>
 					{% endif %}
-
-					<dt>Created by</dt>
-					<dd><a href="{{ url('ms.cp.user.admin.detail.edit', {userID: returnItem.order.user.id}) }}">{{ return.authorship.createdUser.name }}</a> on {{ return.authorship.createdAt|date }}</dd>
+					{% if returnItem.order and returnItem.order.user %}
+						<dt>Created by</dt>
+						<dd><a href="{{ url('ms.cp.user.admin.detail.edit', {userID: returnItem.order.user.id}) }}">{{ return.authorship.createdUser.name }}</a> on {{ return.authorship.createdAt|date }}</dd>
+					{% endif %}
 
 					{% if not returnItem.authorship.updatedAt is empty and not returnItem.authorship.updatedBy is empty %}
 						<dt>Updated by</dt>

--- a/resources/view/return/listing/return-listing.html.twig
+++ b/resources/view/return/listing/return-listing.html.twig
@@ -28,10 +28,20 @@
 
 					<tr>
 						<td><a href="{{ url('ms.commerce.return.view', {returnID: return.id}) }}">{{ return.id }}</a></td>
-						<td><a href="{{ url('ms.commerce.order.view.return', {orderID: returnItem.order.id}) }}">{{ returnItem.order.id }}</a></td>
+						<td>
+							{# May not exist if it is an anon return (e.g. in-store) #}
+							{% if returnItem.order %}
+								<a href="{{ url('ms.commerce.order.view.return', {orderID: returnItem.order.id}) }}">{{ returnItem.order.id }}</a>
+							{% endif %}
+						</td>
 						<td>{{ returnItem.productName }}</td>
 						<td>{{ return.authorship.createdAt|date }}</td>
-						<td><a href="{{ url('ms.cp.user.admin.detail.edit', {userID: returnItem.order.user.id}) }}">{{ return.authorship.createdUser.name }}</a></td>
+						<td>
+							{# May not exist if it is an anon return (e.g. in-store) #}
+							{% if returnItem.order and returnItem.order.user %}
+								<a href="{{ url('ms.cp.user.admin.detail.edit', {userID: returnItem.order.user.id}) }}">{{ return.authorship.createdUser.name }}</a>
+							{% endif %}
+						</td>
 						<td>
 							{% if returnItem.isExchangeResolution %}
 								Exchange

--- a/resources/view/return/order/detail.html.twig
+++ b/resources/view/return/order/detail.html.twig
@@ -51,9 +51,8 @@
 				<dt>Note</dt>
 				<dd>{{ returnItem.note.note }}</dd>
 			{% endif %}
-
-			<dt>Created by</dt>
-			<dd><a href="{{ url('ms.cp.user.admin.detail.edit', {userID: returnItem.order.user.id}) }}">{{ return.authorship.createdUser.name }}</a> on {{ return.authorship.createdAt|date }}</dd>
+			
+			
 
 			{% if not returnItem.authorship.updatedAt is empty and not returnItem.authorship.updatedBy is empty %}
 				<dt>Updated by</dt>

--- a/src/Controller/OrderReturn/Detail.php
+++ b/src/Controller/OrderReturn/Detail.php
@@ -367,7 +367,7 @@ class Detail extends Controller
 
 		// payee == 'customer' || 'retailer'
 		$form->add('balance_amount', 'money', ' ', array(
-			'currency' => $return->item->order->currencyID,
+			'currency' => $return->item->order? $return->item->order->currencyID  : $this->get('currency.company'),
 			'required' => false,
 			'data' => abs($return->item->calculatedBalance) // display the price as positive
 		));


### PR DESCRIPTION
Shops using epos were having issues when creating standalone returns and returns for orders with anon user. The listing and returns details pages were erring whilst trying to create urls and access certain assumed properties.