### PR TITLE
Ignore voided returns in sales reports

### DIFF
--- a/src/Report/AppendQuery/Refunds.php
+++ b/src/Report/AppendQuery/Refunds.php
@@ -63,6 +63,7 @@ class Refunds implements FilterableInterface
 			->leftJoin('return_refund','refund.refund_id = return_refund.refund_id')
 			->leftJoin('order_refund', 'refund.refund_id = order_refund.refund_id')
 			->join('user','user.user_id = refund.created_by')
+			->where('refund.deleted_at IS NULL')
 		;
 
 		// Filter dates

--- a/src/Report/AppendQuery/Returns.php
+++ b/src/Report/AppendQuery/Returns.php
@@ -88,6 +88,7 @@ class Returns implements FilterableInterface
 			->where('product.type != "voucher"')
 			->where('item.status_code >= 2200')
 			->where('item.return_id NOT IN (?q)', [$voids]) // Ignore voided returns
+			->where('return.deleted_at IS NULL')
 		;
 
 		// Filter dates

--- a/src/Report/AppendQuery/Returns.php
+++ b/src/Report/AppendQuery/Returns.php
@@ -52,6 +52,14 @@ class Returns implements FilterableInterface
 	{
 		$data = $this->_builderFactory->getQueryBuilder();
 
+		$voids = $this->_builderFactory->getQueryBuilder()
+			->select('transaction_record.record_id', true)
+			->from('transaction')
+			->joinUsing('transaction_record', 'transaction_id')
+			->where('transaction.type = ?s', ['return'])
+			->where('transaction.voided_at IS NOT NULL')
+		;
+
 		$data
 			->select('item.completed_at AS "Date"')
 			->select('return.currency_id AS "Currency"')
@@ -79,6 +87,7 @@ class Returns implements FilterableInterface
 			->leftJoin('product', 'item.product_id = product.product_id')
 			->where('product.type != "voucher"')
 			->where('item.status_code >= 2200')
+			->where('item.return_id NOT IN (?q)', [$voids]) // Ignore voided returns
 		;
 
 		// Filter dates

--- a/src/Report/AppendQuery/Returns.php
+++ b/src/Report/AppendQuery/Returns.php
@@ -56,7 +56,7 @@ class Returns implements FilterableInterface
 			->select('transaction_record.record_id', true)
 			->from('transaction')
 			->joinUsing('transaction_record', 'transaction_id')
-			->where('transaction.type = ?s', ['return'])
+			->where('transaction_record.type = ?s', ['return'])
 			->where('transaction.voided_at IS NOT NULL')
 		;
 


### PR DESCRIPTION
This PR ignores voided returns in the sales reports. See https://github.com/mothership-ec/cog-mothership-commerce/pull/501
